### PR TITLE
feat: add disk scheduler

### DIFF
--- a/storage/disk/disk_scheduler.go
+++ b/storage/disk/disk_scheduler.go
@@ -1,1 +1,88 @@
 package disk
+
+import (
+	"sync"
+)
+
+func NewScheduler(diskManager *diskManager) *DiskScheduler {
+	ds := &DiskScheduler{
+		reqCh:       make(chan DiskReq, 100),
+		pageQueue:   make(map[int]chan DiskReq),
+		pageQueueMu: sync.Mutex{},
+		diskManager: diskManager,
+	}
+
+	go ds.handleDiskReq()
+	return ds
+}
+
+func (ds *DiskScheduler) Schedule(req DiskReq) {
+	ds.reqCh <- req
+}
+
+func (ds *DiskScheduler) handleDiskReq() {
+	for req := range ds.reqCh {
+		ds.pageQueueMu.Lock()
+		_, ok := ds.pageQueue[req.PageId]
+		if !ok {
+			ds.pageQueue[req.PageId] = make(chan DiskReq, 10)
+		}
+		ds.pageQueueMu.Unlock()
+
+		ds.pageQueue[req.PageId] <- req
+
+		// !ok means we created a new page queue, therefore we should start a
+		// new worker to handle the queue's page requests
+		if !ok {
+			go ds.pageWorker(req.PageId, ds.pageQueue[req.PageId])
+		}
+	}
+}
+
+func (ds *DiskScheduler) pageWorker(pageId int, reqQueue chan DiskReq) {
+	for {
+		req, ok := <-reqQueue
+		if !ok {
+			break
+		}
+
+		if req.Write {
+			if err := ds.diskManager.writePage(req.PageId, req.Data); err != nil {
+				req.RespCh <- DiskResp{Success: false}
+			} else {
+				req.RespCh <- DiskResp{Success: true}
+			}
+		} else {
+			if data, err := ds.diskManager.readPage(req.PageId); err != nil {
+				req.RespCh <- DiskResp{Success: false}
+			} else {
+				req.RespCh <- DiskResp{Success: true, Data: data}
+			}
+		}
+	}
+
+	// done handling request for this page, can remove it from queue
+	ds.pageQueueMu.Lock()
+	delete(ds.pageQueue, pageId)
+	ds.pageQueueMu.Unlock()
+}
+
+type DiskScheduler struct {
+	reqCh       chan DiskReq
+	diskManager *diskManager
+
+	pageQueue   map[int]chan DiskReq
+	pageQueueMu sync.Mutex
+}
+
+type DiskReq struct {
+	PageId int
+	Data   []byte
+	Write  bool
+	RespCh chan DiskResp
+}
+
+type DiskResp struct {
+	Success bool
+	Data    []byte
+}

--- a/storage/disk/disk_scheduler_test.go
+++ b/storage/disk/disk_scheduler_test.go
@@ -1,1 +1,74 @@
 package disk
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiskScheduler(t *testing.T) {
+	t.Run("schedule is non blocking", func(t *testing.T) {
+		file := CreateDbFile(t)
+		t.Cleanup(func() {
+			_ = os.Remove(file.Name())
+		})
+
+		diskMgr := NewDiskManager(file)
+		ds := NewScheduler(diskMgr)
+
+		resCh := make(chan DiskResp)
+		data := make([]byte, PAGE_SIZE)
+		copy(data, []byte("hello world"))
+
+		writeReq := DiskReq{
+			PageId: 1,
+			Write:  true,
+			Data:   data,
+			RespCh: resCh,
+		}
+
+		start := time.Now()
+		ds.Schedule(writeReq)
+		elapsed := time.Since(start)
+
+		assert.Less(t, elapsed, time.Millisecond)
+	})
+
+	t.Run("can schedule read and write requests", func(t *testing.T) {
+		file := CreateDbFile(t)
+		t.Cleanup(func() {
+			_ = os.Remove(file.Name())
+		})
+
+		diskMgr := NewDiskManager(file)
+		ds := NewScheduler(diskMgr)
+
+		resCh := make(chan DiskResp)
+		data := make([]byte, PAGE_SIZE)
+		copy(data, []byte("hello world"))
+
+		writeReq := DiskReq{
+			PageId: 1,
+			Write:  true,
+			Data:   data,
+			RespCh: resCh,
+		}
+
+		respCh := make(chan DiskResp)
+		readReq := DiskReq{
+			PageId: 1,
+			Write:  false,
+			RespCh: respCh,
+		}
+
+		ds.Schedule(writeReq)
+		ds.Schedule(readReq)
+
+		<-writeReq.RespCh
+		res := <-readReq.RespCh
+		assert.Equal(t, res.Data, data)
+	})
+
+}


### PR DESCRIPTION
## Overview

Adds a non blocking scheduler

## Notes

`DiskScheduler` provides a non blocking `Schedule` method and takes advantage of internal disk parallelism by mantaining per page queues. Assuming we have two pages 1 & 2, then their disk requests will handled in parallel. 