### PR TITLE
Int64 offset

### DIFF
--- a/storage/disk/disk_manager.go
+++ b/storage/disk/disk_manager.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-func NewDiskManager(file *os.File) *diskManager {
+func NewManager(file *os.File) *diskManager {
 	return &diskManager{
 		dbFile:       file,
 		pageCapacity: DEFAULT_PAGE_CAPACITY,

--- a/storage/disk/disk_manager.go
+++ b/storage/disk/disk_manager.go
@@ -9,13 +9,13 @@ func NewManager(file *os.File) *diskManager {
 	return &diskManager{
 		dbFile:       file,
 		pageCapacity: DEFAULT_PAGE_CAPACITY,
-		freeSlots:    []int{},
-		pages:        map[int]int{},
+		freeSlots:    []int64{},
+		pages:        map[int]int64{},
 	}
 }
 
 func (dm *diskManager) writePage(pageId int, data []byte) error {
-	var offset int
+	var offset int64
 	offset, pageFound := dm.pages[pageId]
 
 	if !pageFound {
@@ -26,7 +26,7 @@ func (dm *diskManager) writePage(pageId int, data []byte) error {
 		dm.pages[pageId] = offset
 	}
 
-	_, err := dm.dbFile.WriteAt(data, int64(offset))
+	_, err := dm.dbFile.WriteAt(data, offset)
 
 	if err != nil {
 		return fmt.Errorf("error writing at offset %d: %v", offset, err)
@@ -36,7 +36,7 @@ func (dm *diskManager) writePage(pageId int, data []byte) error {
 }
 
 func (dm *diskManager) readPage(pageId int) ([]byte, error) {
-	var offset int
+	var offset int64
 	offset, pageFound := dm.pages[pageId]
 
 	if !pageFound {
@@ -48,7 +48,7 @@ func (dm *diskManager) readPage(pageId int) ([]byte, error) {
 	}
 
 	buf := make([]byte, PAGE_SIZE)
-	if _, err := dm.dbFile.ReadAt(buf, int64(offset)); err != nil {
+	if _, err := dm.dbFile.ReadAt(buf, offset); err != nil {
 		return nil, fmt.Errorf("error reading from offset %d: %v", offset, err)
 	}
 
@@ -62,7 +62,7 @@ func (dm *diskManager) deletePage(pageId int) {
 	}
 }
 
-func (dm *diskManager) allocatePage() (int, error) {
+func (dm *diskManager) allocatePage() (int64, error) {
 	if len(dm.freeSlots) > 0 {
 		offset := dm.freeSlots[0]
 		dm.freeSlots = dm.freeSlots[1:]
@@ -80,13 +80,13 @@ func (dm *diskManager) allocatePage() (int, error) {
 	return dm.getNextOffset(), nil
 }
 
-func (dm *diskManager) getNextOffset() int {
-	return len(dm.pages) * PAGE_SIZE
+func (dm *diskManager) getNextOffset() int64 {
+	return int64(len(dm.pages) * PAGE_SIZE)
 }
 
 type diskManager struct {
 	dbFile       *os.File
-	pages        map[int]int
-	freeSlots    []int
+	pages        map[int]int64
+	freeSlots    []int64
 	pageCapacity int
 }

--- a/storage/disk/disk_manager_test.go
+++ b/storage/disk/disk_manager_test.go
@@ -25,8 +25,8 @@ func TestDiskManager(t *testing.T) {
 		dm.pages[1] = offset2
 		assert.NoError(t, err)
 
-		assert.Equal(t, 0, offset1)
-		assert.Equal(t, 4096, offset2)
+		assert.Equal(t, int64(0), offset1)
+		assert.Equal(t, int64(4096), offset2)
 	})
 
 	t.Run("allocate reuses free slots", func(t *testing.T) {
@@ -36,12 +36,12 @@ func TestDiskManager(t *testing.T) {
 		})
 
 		dm := NewManager(dbFile)
-		dm.freeSlots = []int{8192}
+		dm.freeSlots = []int64{8192}
 
 		offset, err := dm.allocatePage()
 		assert.NoError(t, err)
 
-		assert.Equal(t, 8192, offset)
+		assert.Equal(t, int64(8192), offset)
 		assert.Empty(t, dm.freeSlots)
 	})
 
@@ -54,14 +54,14 @@ func TestDiskManager(t *testing.T) {
 
 		dm := NewManager(dbFile)
 		dm.pageCapacity = 1
-		dm.pages = map[int]int{
+		dm.pages = map[int]int64{
 			0: 0,
 		}
 
 		offset, err := dm.allocatePage()
 		assert.NoError(t, err)
 
-		assert.Equal(t, 4096, offset)
+		assert.Equal(t, int64(4096), offset)
 		assert.Equal(t, 2, dm.pageCapacity)
 
 		// dbFile is increased in size

--- a/storage/disk/disk_manager_test.go
+++ b/storage/disk/disk_manager_test.go
@@ -16,7 +16,7 @@ func TestDiskManager(t *testing.T) {
 			_ = os.Remove(dbFile.Name())
 		})
 
-		dm := NewDiskManager(dbFile)
+		dm := NewManager(dbFile)
 		offset1, err := dm.allocatePage()
 		dm.pages[0] = offset1
 		assert.NoError(t, err)
@@ -35,7 +35,7 @@ func TestDiskManager(t *testing.T) {
 			_ = os.Remove(dbFile.Name())
 		})
 
-		dm := NewDiskManager(dbFile)
+		dm := NewManager(dbFile)
 		dm.freeSlots = []int{8192}
 
 		offset, err := dm.allocatePage()
@@ -52,7 +52,7 @@ func TestDiskManager(t *testing.T) {
 			_ = os.Remove(dbFile.Name())
 		})
 
-		dm := NewDiskManager(dbFile)
+		dm := NewManager(dbFile)
 		dm.pageCapacity = 1
 		dm.pages = map[int]int{
 			0: 0,
@@ -76,7 +76,7 @@ func TestDiskManager(t *testing.T) {
 			_ = os.Remove(dbFile.Name())
 		})
 
-		dm := NewDiskManager(dbFile)
+		dm := NewManager(dbFile)
 		dm.pageCapacity = 1
 
 		buf := make([]byte, PAGE_SIZE)
@@ -98,7 +98,7 @@ func TestDiskManager(t *testing.T) {
 			_ = os.Remove(dbFile.Name())
 		})
 
-		dm := NewDiskManager(dbFile)
+		dm := NewManager(dbFile)
 		dm.pageCapacity = 1
 		dm.pages[1] = 0
 		assert.Equal(t, len(dm.freeSlots), 0)

--- a/storage/disk/disk_scheduler_test.go
+++ b/storage/disk/disk_scheduler_test.go
@@ -15,7 +15,7 @@ func TestDiskScheduler(t *testing.T) {
 			_ = os.Remove(file.Name())
 		})
 
-		diskMgr := NewDiskManager(file)
+		diskMgr := NewManager(file)
 		ds := NewScheduler(diskMgr)
 
 		resCh := make(chan DiskResp)
@@ -42,7 +42,7 @@ func TestDiskScheduler(t *testing.T) {
 			_ = os.Remove(file.Name())
 		})
 
-		diskMgr := NewDiskManager(file)
+		diskMgr := NewManager(file)
 		ds := NewScheduler(diskMgr)
 
 		resCh := make(chan DiskResp)


### PR DESCRIPTION
## Overview

Use int64 offsets

## Notes

int64 offsets can address a larger amount of pages compared to int offsets.
