### PR TITLE
refactor bufferpool page access

### DIFF
--- a/buffer/bufferpool_manager.go
+++ b/buffer/bufferpool_manager.go
@@ -8,14 +8,21 @@ import (
 	"github.com/jobala/petro/storage/disk"
 )
 
+type mode = int
+
+const (
+	write mode = iota
+	read
+)
+
 func NewBufferpoolManager(size int, replacer *lrukReplacer, diskScheduler *disk.DiskScheduler) *BufferpoolManager {
-	frames := make([]*frame, size)
+	frames := make([]*Frame, size)
 	freeFrames := make([]int, size)
 
 	for i := range size {
-		f := &frame{
+		f := &Frame{
 			id:   i,
-			data: make([]byte, disk.PAGE_SIZE),
+			Data: make([]byte, disk.PAGE_SIZE),
 		}
 
 		frames[i] = f
@@ -37,7 +44,7 @@ func NewBufferpoolManager(size int, replacer *lrukReplacer, diskScheduler *disk.
 func (b *BufferpoolManager) ReadPage(pageId int64) (*ReadPageGuard, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	var frame *frame
+	var frame *Frame
 
 	for {
 		if id, ok := b.pageTable[pageId]; ok {
@@ -78,7 +85,7 @@ func (b *BufferpoolManager) ReadPage(pageId int64) (*ReadPageGuard, error) {
 			diskReq := disk.NewRequest(pageId, nil, false)
 			respCh := b.diskScheduler.Schedule(diskReq)
 			resp := <-respCh
-			copy(frame.data, resp.Data)
+			copy(frame.Data, resp.Data)
 
 			return NewReadPageGuard(frame, b), nil
 		}
@@ -92,7 +99,7 @@ func (b *BufferpoolManager) WritePage(pageId int64) (*WritePageGuard, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	var frame *frame
+	var frame *Frame
 
 	for {
 		if id, ok := b.pageTable[pageId]; ok {
@@ -136,7 +143,7 @@ func (b *BufferpoolManager) WritePage(pageId int64) (*WritePageGuard, error) {
 			diskReq := disk.NewRequest(pageId, nil, false)
 			respCh := b.diskScheduler.Schedule(diskReq)
 			resp := <-respCh
-			copy(frame.data, resp.Data)
+			copy(frame.Data, resp.Data)
 			return NewWritePageGuard(frame, b), nil
 		}
 
@@ -147,13 +154,101 @@ func (b *BufferpoolManager) WritePage(pageId int64) (*WritePageGuard, error) {
 	}
 }
 
+func (b *BufferpoolManager) GetPage(pageId int64, accessMode mode, callback func(frame *Frame)) {
+	var frame *Frame
+
+	b.mu.Lock()
+	for {
+		if id, ok := b.pageTable[pageId]; ok {
+			frame = b.frames[id]
+
+			frame.pin()
+			if accessMode == write {
+				frame.mu.Lock()
+				frame.dirty = true
+			} else {
+				frame.mu.RLock()
+			}
+
+			b.replacer.recordAccess(frame.id)
+			b.replacer.setEvictable(frame.id, false)
+			break
+		}
+
+		// try getting a frame
+		if len(b.freeFrames) > 0 {
+			id := b.freeFrames[0]
+			frame = b.frames[id]
+			b.freeFrames = b.freeFrames[1:]
+		} else {
+			if id, _ := b.replacer.evict(); id != disk.INVALID_PAGE_ID {
+				frame = b.frames[id]
+				b.flush(frame)
+			}
+		}
+
+		// got the frame, return a page guard
+		if frame != nil {
+			delete(b.pageTable, frame.pageId)
+			b.pageTable[pageId] = frame.id
+			b.replacer.recordAccess(frame.id)
+			b.replacer.setEvictable(frame.id, false)
+
+			frame.reset()
+			if accessMode == write {
+				frame.mu.Lock()
+				frame.dirty = true
+			} else {
+				frame.mu.RLock()
+			}
+
+			frame.pin()
+			frame.pageId = pageId
+
+			diskReq := disk.NewRequest(pageId, nil, false)
+			respCh := b.diskScheduler.Schedule(diskReq)
+			resp := <-respCh
+			frame.Data = resp.Data
+			break
+		}
+
+		// failed to get a frame, wait for a frame to become available
+		// pageGuard.Drop will send a signal
+		fmt.Println("waiting for a frame to become available", len(b.freeFrames))
+		b.cond.Wait()
+	}
+	b.mu.Unlock()
+
+	defer func(frame *Frame) {
+		if frame == nil || b == nil {
+			return
+		}
+
+		frame.unpin()
+		if frame.pins.Load() == 0 {
+			b.replacer.setEvictable(frame.id, true)
+		}
+
+		if accessMode == write {
+			frame.mu.Unlock()
+		} else {
+			frame.mu.RUnlock()
+		}
+
+		b.cond.Signal()
+	}(frame)
+
+	// do something with the frame
+	callback(frame)
+}
+
 func (b *BufferpoolManager) NewPageId() int64 {
 	return b.nextPageId.Add(1)
 }
 
-func (b *BufferpoolManager) flush(frame *frame) {
+func (b *BufferpoolManager) flush(frame *Frame) {
 	if frame.dirty {
-		writeReq := disk.NewRequest(frame.pageId, frame.data, true)
+		writeReq := disk.NewRequest(frame.pageId, frame.Data, true)
 		respCh := b.diskScheduler.Schedule(writeReq)
 
 		// block until data is written to disk
@@ -163,7 +258,7 @@ func (b *BufferpoolManager) flush(frame *frame) {
 
 type BufferpoolManager struct {
 	mu            sync.Mutex
-	frames        []*frame
+	frames        []*Frame
 	pageTable     map[int64]int
 	nextPageId    atomic.Int64
 	diskScheduler *disk.DiskScheduler

--- a/buffer/frame.go
+++ b/buffer/frame.go
@@ -7,24 +7,24 @@ import (
 	"github.com/jobala/petro/storage/disk"
 )
 
-func (f *frame) pin() {
+func (f *Frame) pin() {
 	f.pins.Add(1)
 }
 
-func (f *frame) unpin() int32 {
+func (f *Frame) unpin() int32 {
 	return f.pins.Add(-1)
 }
 
-func (f *frame) reset() {
+func (f *Frame) reset() {
 	f.dirty = false
 	f.pins.Store(0)
-	f.data = make([]byte, disk.PAGE_SIZE)
+	f.Data = make([]byte, disk.PAGE_SIZE)
 }
 
-type frame struct {
+type Frame struct {
+	Data   []byte
 	mu     sync.RWMutex
 	id     int
-	data   []byte
 	pins   atomic.Int32
 	dirty  bool
 	pageId int64

--- a/buffer/page_guard.go
+++ b/buffer/page_guard.go
@@ -1,8 +1,8 @@
 package buffer
 
 import (
-	"bytes"
-	"encoding/gob"
+	"github.com/jobala/petro/storage/disk"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 func NewReadPageGuard(frame *frame, bpm *BufferpoolManager) *ReadPageGuard {
@@ -64,20 +64,21 @@ func (pg *WritePageGuard) GetDataMut() *[]byte {
 }
 
 func ToByteSlice[T any](obj T) ([]byte, error) {
-	var buffer bytes.Buffer
-	gob := gob.NewEncoder(&buffer)
-	if err := gob.Encode(obj); err != nil {
+	res := make([]byte, disk.PAGE_SIZE)
+
+	data, err := msgpack.Marshal(obj)
+	if err != nil {
 		return nil, err
 	}
+	copy(res, data)
 
-	return buffer.Bytes(), nil
+	return res, nil
 }
 
 func ToStruct[T any](data []byte) (T, error) {
 	var res T
-	gob := gob.NewDecoder(bytes.NewReader(data))
-	if err := gob.Decode(&res); err != nil {
 
+	if err := msgpack.Unmarshal(data, &res); err != nil {
 		return res, nil
 	}
 

--- a/buffer/page_guard.go
+++ b/buffer/page_guard.go
@@ -5,7 +5,7 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
-func NewReadPageGuard(frame *frame, bpm *BufferpoolManager) *ReadPageGuard {
+func NewReadPageGuard(frame *Frame, bpm *BufferpoolManager) *ReadPageGuard {
 	return &ReadPageGuard{
 		PageGuard: PageGuard{
 			frame: frame,
@@ -14,7 +14,7 @@ func NewReadPageGuard(frame *frame, bpm *BufferpoolManager) *ReadPageGuard {
 	}
 }
 
-func NewWritePageGuard(frame *frame, bpm *BufferpoolManager) *WritePageGuard {
+func NewWritePageGuard(frame *Frame, bpm *BufferpoolManager) *WritePageGuard {
 	return &WritePageGuard{
 		PageGuard: PageGuard{
 			frame: frame,
@@ -56,11 +56,11 @@ func (pg *WritePageGuard) Drop() {
 }
 
 func (pg *ReadPageGuard) GetData() []byte {
-	return pg.frame.data
+	return pg.frame.Data
 }
 
 func (pg *WritePageGuard) GetDataMut() *[]byte {
-	return &pg.frame.data
+	return &pg.frame.Data
 }
 
 func ToByteSlice[T any](obj T) ([]byte, error) {
@@ -86,7 +86,7 @@ func ToStruct[T any](data []byte) (T, error) {
 }
 
 type PageGuard struct {
-	frame *frame
+	frame *Frame
 	bpm   *BufferpoolManager
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,7 @@ require github.com/stretchr/testify v1.10.0
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/index/b_plus_tree_test.go
+++ b/index/b_plus_tree_test.go
@@ -51,13 +51,13 @@ func TestBPlusTree(t *testing.T) {
 		bplus, err := NewBplusTree[int, int]("test", bpm)
 		assert.NoError(t, err)
 
-		for i := 40; i >= 0; i-- {
+		for i := 20000; i >= 0; i-- {
 			inserted, err := bplus.insert(i, i)
 			assert.NoError(t, err)
 			assert.True(t, inserted)
 		}
 
-		for i := range 40 {
+		for i := range 20000 {
 			val, err := bplus.getValue(i)
 			if err != nil {
 				fmt.Println(err)


### PR DESCRIPTION
## Overview

Refactors Bufferpool page access pattern from guards to callbacks.

## Notes

Page guards were bug prone because they have to be dropped manually when done. Forgetting to drop a guard results in hard to debug locks.

